### PR TITLE
Removed .lstrip() to fix KeyError and added model_config to fix Pydantic

### DIFF
--- a/instagrapi/mixins/public.py
+++ b/instagrapi/mixins/public.py
@@ -205,7 +205,7 @@ class PublicRequestMixin:
             self.last_response_ts = time.time()
 
     def public_a1_request(self, endpoint, data=None, params=None, headers=None):
-        url = self.PUBLIC_API_URL + endpoint.lstrip("/")
+        url = self.PUBLIC_API_URL + endpoint  # (jarrodnorwell) fixed KeyError: 'data'
         params = params or {}
         params.update({"__a": 1, "__d": "dis"})
 

--- a/instagrapi/types.py
+++ b/instagrapi/types.py
@@ -1,7 +1,14 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, FilePath, HttpUrl, ValidationError, validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    FilePath,
+    HttpUrl,
+    ValidationError,
+    validator,
+)
 
 
 def validate_external_url(cls, v):
@@ -11,6 +18,10 @@ def validate_external_url(cls, v):
 
 
 class Resource(BaseModel):
+    model_config = ConfigDict(
+        coerce_numbers_to_str=True
+    )  # (jarrodnorwell) fixed pk issue
+
     pk: str
     video_url: Optional[HttpUrl] = None  # for Video and IGTV
     thumbnail_url: HttpUrl
@@ -73,6 +84,10 @@ class Account(BaseModel):
 
 
 class UserShort(BaseModel):
+    model_config = ConfigDict(
+        coerce_numbers_to_str=True
+    )  # (jarrodnorwell) fixed pk issue
+
     pk: str
     username: Optional[str] = None
     full_name: Optional[str] = ""

--- a/requirements.lock
+++ b/requirements.lock
@@ -11,7 +11,7 @@ Pillow==8.2.0
 pip==21.0.1
 proglog==0.1.9
 pycryptodomex==3.9.9
-pydantic==2.4.2
+pydantic==2.5.2
 PySocks==1.7.1
 requests==2.25.1
 setuptools==53.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.31.0
 PySocks==1.7.1
-pydantic==2.4.2
+pydantic==2.5.2
 moviepy==1.0.3
 pycryptodomex==3.18.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ Features:
 requirements = [
     "requests<3.0,>=2.25.1",
     "PySocks==1.7.1",
-    "pydantic==2.4.2",
+    "pydantic==2.5.2",
     "pycryptodomex==3.18.0",
 ]
 # requirements = [


### PR DESCRIPTION
Using `hashtag_medias_recent` and `hashtag_medias_top` initially prompts an issue where `data` could not be found in the returned GraphQL data, removing `.lstrip("/")` fixes this issue.

Additionally, fixing the above issue prompts a Pydantic issue with `Resource` and `UserShort` due to `pk` being `int` but requiring the `str`, adding `model_config` with `coerce_numbers_to_str=True` fixes this issue.

More testing may be required, I've only tried with liking by hashtag.